### PR TITLE
Use a more precise type for nfIO'

### DIFF
--- a/criterion-measurement/src/Criterion/Measurement/Types.hs
+++ b/criterion-measurement/src/Criterion/Measurement/Types.hs
@@ -332,7 +332,7 @@ whnfAppIO f v = toBenchmarkable (whnfAppIO' f v)
 
 -- | Generate a function that will run an action a given number of times,
 -- reducing it to normal form each time.
-nfIO' :: (a -> b) -> IO a -> (Int64 -> IO ())
+nfIO' :: (a -> ()) -> IO a -> (Int64 -> IO ())
 nfIO' reduce a = go
   where go n
           | n <= 0    = return ()


### PR DESCRIPTION
Its first argument is supposed to be a function which reduces the result to normal form. Specifying its type as 'a -> ()', rather than 'a -> b' conveys this intention better. Also, presently nfIO' is an internal function used only by nfIO, which uses 'rnf' as a reducer.

Anyway, this is a really minor thing. I was looking at this file for something and happened to notice this.