### PR TITLE
Make C code work on Intel- and ARM-based Macs

### DIFF
--- a/criterion-measurement/cbits/cycles.c
+++ b/criterion-measurement/cbits/cycles.c
@@ -1,6 +1,15 @@
 #include "Rts.h"
 
-#if x86_64_HOST_ARCH || i386_HOST_ARCH
+#if darwin_HOST_OS
+
+#include <mach/mach_time.h>
+
+StgWord64 criterion_rdtsc(void)
+{
+  return mach_absolute_time();
+}
+
+#elif x86_64_HOST_ARCH || i386_HOST_ARCH
 
 StgWord64 criterion_rdtsc(void)
 {

--- a/criterion-measurement/cbits/time-osx.c
+++ b/criterion-measurement/cbits/time-osx.c
@@ -1,20 +1,11 @@
 #include <mach/mach.h>
-#include <mach/mach_time.h>
+#include <time.h>
 
-static mach_timebase_info_data_t timebase_info;
-static double timebase_recip;
-
-void criterion_inittime(void)
-{
-    if (timebase_recip == 0) {
-	mach_timebase_info(&timebase_info);
-	timebase_recip = (timebase_info.denom / timebase_info.numer) / 1e9;
-    }
-}
+void criterion_inittime(void) {}
 
 double criterion_gettime(void)
 {
-    return mach_absolute_time() * timebase_recip;
+    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / 1e9;
 }
 
 static double to_double(time_value_t time)

--- a/criterion-measurement/changelog.md
+++ b/criterion-measurement/changelog.md
@@ -1,3 +1,28 @@
+next
+
+* Change `criterion_rdtsc` to return `mach_absolute_time` on macOS. This is a
+  portable way of returning the number of CPU cycles that works on both Intel-
+  and ARM-based Macs.
+
+* Change `criterion_gettime` to use `clock_gettime_nsec_np` instead of
+  `mach_absolute_time` on macOS. While `mach_absolute_time` has nanosecond
+  resolution on Intel-based Macs, this is not the case on ARM-based Macs, so
+  the previous `mach_absolute_time`-based implementation would return incorrect
+  timing results on Apple silicon.
+
+  There are two minor consequences of this change:
+
+  * `criterion-measurement` now only supports macOS 10.02 or later, as that is
+    the first version to have `clock_gettime_nsec_np`. As macOS 10.02 was
+    released in 2002, this is unlikely to affect users, but please speak up if
+    this is a problem for you.
+
+  * As `clock_gettime_nsec_np` does not require any special initialization
+    code, `criterion_inittime` is now a no-op on macOS. If you manually invoke
+    the `getTime` function in your code, however, it is still important that
+    you `initializeTime` beforehand, as this is still required for the Windows
+    implementation to work correctly.
+
 0.1.2.0
 
 * Ensure that `Criterion.Measurement.Types.Internal` is always compiled with


### PR DESCRIPTION
This applies two tweaks to `cycles.c` and `time-osx.c` to ensure that `criterion_rdtsc` and `criterion_gettime` work on all versions of macOS, regardless of the architecture being used. In particular, this is required to make `criterion-measurement` compile and run on Apple silicon.

Fixes #238.