### PR TITLE
Remove direct dependency on deprecated library

### DIFF
--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -36,13 +36,12 @@ import Data.Version (showVersion)
 import GHC.Generics (Generic)
 import Options.Applicative
 import Options.Applicative.Help (Chunk(..))
-import Options.Applicative.Help.Pretty ((.$.))
+import Options.Applicative.Help.Pretty ((.$.), Doc, text)
 import Options.Applicative.Types
 import Paths_criterion (version)
 import Prelude ()
 import Prelude.Compat
 import Statistics.Types (mkCL,cl95)
-import Text.PrettyPrint.ANSI.Leijen (Doc, text)
 import qualified Data.Map as M
 
 -- | How to match a benchmark name.
@@ -243,5 +242,5 @@ versionInfo = "built with criterion " <> showVersion version
 regressionHelp :: Chunk Doc
 regressionHelp =
     fmap (text "Regression metrics (for use with --regress):" .$.) $
-      tabulate [(text n,text d) | (n,(_,d)) <- map f measureKeys]
+      tabulate [(text n, text d) | (n,(_,d)) <- map f measureKeys]
   where f k = (k, measureAccessors M.! k)

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -85,7 +85,6 @@ library
     -- TODO: Eventually, we should bump the lower version bounds to >=2 so that
     -- we can remove some CPP in Criterion.Report. See #247.
     aeson >= 1 && < 2.2,
-    ansi-wl-pprint >= 0.6.7.2,
     base >= 4.5 && < 5,
     base-compat-batteries >= 0.10 && < 0.13,
     binary >= 0.5.1.0,


### PR DESCRIPTION
This PR is related to https://github.com/pcapriotti/optparse-applicative/pull/428 making it possible for `optparse-applicative` evolve in a way that incurs less breakage, but I think PR itself also has it own merits.