### PR TITLE
Use default value for `regressions` when creating `config`

### DIFF
--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -133,7 +133,8 @@ config Config{..} = Config
   <*> option (range 1 1000000)
       (long "resamples" <> metavar "COUNT" <> value resamples <>
        help "Number of bootstrap resamples to perform")
-  <*> many (option regressParams
+  <*> manyDefault regressions
+           (option regressParams
             (long "regress" <> metavar "RESP:PRED.." <>
              help "Regressions to perform"))
   <*> outputOption rawDataFile (long "raw" <>
@@ -153,6 +154,12 @@ config Config{..} = Config
   <*> strOption (long "template" <> short 't' <> metavar "FILE" <>
                  value template <>
                  help "Template to use for report")
+
+manyDefault :: [a] -> Parser a -> Parser [a]
+manyDefault def m = set_default <$> many m
+  where
+    set_default [] = def
+    set_default xs = xs
 
 outputOption :: Maybe String -> Mod OptionFields String -> Parser (Maybe String)
 outputOption file m =


### PR DESCRIPTION
Previously, the `config` function would ignore the value of `regressions` that specified (e.g., via the `Config` argument of
`defaultMain`). Since `--regressions` is an argument that is allowed to be passed multiple times, it's somewhat awkward to specify a default argument for it. I adopt a similar approach to what the old `arguments1` function in `optparse-applicative` did (see https://github.com/pcapriotti/optparse-applicative/commit/700e07b0751d02fec938af67d1f917e60974a601).

Fixes #244.