### PR TITLE
Add peak bytes allocated field to Measured

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+1.6.0.0
+
+* `criterion-measurement-0.2.0.0` adds the `measPeakMbAllocated` field to
+  `Measured` for reporting maximum megabytes allocated. Naturally, this
+  affects the JSON and Binary interfaces.
+
 1.5.13.0
 
 * Allow building with `optparse-applicative-0.17.*`.

--- a/criterion-measurement/changelog.md
+++ b/criterion-measurement/changelog.md
@@ -1,3 +1,8 @@
+0.2.0.0
+
+* Adds the `measPeakMbAllocated` field to `Measured` for reporting maximum
+  megabytes allocated. Naturally, this affects the JSON and Binary interfaces.
+
 0.1.3.0
 
 * Change `criterion_rdtsc` to return `mach_absolute_time` on macOS. This is a

--- a/criterion-measurement/criterion-measurement.cabal
+++ b/criterion-measurement/criterion-measurement.cabal
@@ -1,5 +1,5 @@
 name:                criterion-measurement
-version:             0.1.3.0
+version:             0.2.0.0
 synopsis:            Criterion measurement functionality and associated types
 description:         Measurement-related functionality extracted from Criterion, with minimal dependencies. The rationale for this is to enable alternative analysis front-ends.
 homepage:            https://github.com/haskell/criterion

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -1,5 +1,5 @@
 name:           criterion
-version:        1.5.13.0
+version:        1.6.0.0
 synopsis:       Robust, reliable performance measurement and analysis
 license:        BSD3
 license-file:   LICENSE
@@ -94,7 +94,7 @@ library
     cassava >= 0.3.0.0,
     code-page,
     containers,
-    criterion-measurement >= 0.1.1.0 && < 0.2,
+    criterion-measurement >= 0.1.1.0 && < 0.3,
     deepseq >= 1.1.0.0,
     directory,
     exceptions >= 0.8.2 && < 0.11,

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -12,7 +12,7 @@ import Test.HUnit
 r1 :: Report
 r1 = Report 0 "" [] v1 s1 (Outliers 0 0 0 0 0) []
  where
-  m1 = Measured 4.613000783137977e-05 3.500000000000378e-05 31432 1 0 0 0 0.0 0.0 0.0 0.0
+  m1 = Measured 4.613000783137977e-05 3.500000000000378e-05 31432 1 0 0 0 0 0.0 0.0 0.0 0.0
   v1 = V.fromList [m1]
   est1 = estimateFromErr 0.0 (0.0, 0.0) (mkCL 0.0)
   s1 = SampleAnalysis [] est1 est1 (OutlierVariance Unaffected "" 0.0)
@@ -24,6 +24,7 @@ m2 = Measured {measTime = 1.1438998626545072e-5
               , measIters = 1
 
               , measAllocated = minBound
+              , measPeakMbAllocated = minBound
               , measNumGcs = minBound
               , measBytesCopied = minBound
 


### PR DESCRIPTION
Adds the "peak mb allocated" to the json output for #256.

I wasn't sure which "max mb" stat we wanted to take here, so I took the final `endPostGC` one. In my testing `endPostGC`, `endStatsPreGC`, and `startStats` were all the same, in any case. 
```haskell
  measAllocated         = diff endPostGC gcStatsBytesAllocated
, measPeakMbAllocated   = gcStatsPeakMegabytesAllocated endPostGC
```

Example:
```json5
{
  "reportMeasured": [
    [
      4.930255000090256e-3,
      1.1697070000000007e-3,
      11361858,
      1,
      1236872,
      3,                /* peakMbAllocated */
      1,
      189848,
      4.644875e-3,
      8.848910000000001e-4,
      2.9445099999999983e-4,
      2.93705e-4
    ]
  ],
  ...
  "reportKeys": [
    "time",
    "cpuTime",
    "cycles",
    "iters",
    "allocated",
    "peakMbAllocated",
    "numGcs",
    "bytesCopied",
    "mutatorWallSeconds",
    "mutatorCpuSeconds",
    "gcWallSeconds",
    "gcCpuSeconds"
  ]
}
```

