### PR TITLE
Fix #168 (again) by factoring out common sub-`Parser`s

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
   re-exports `Measured` from `Criterion.Types`, this change affects `criterion`
   as well. Naturally, this affects the behavior of `Measured`'s `{To,From}JSON`
   and `Binary` instances.
+* Fix a bug in which the `--help` text for the `--match` option was printed
+  twice in `criterion` applications.
 
 1.5.13.0
 


### PR DESCRIPTION
I thought I had fixed #168 in 45c135d67980c3690c3ad8f01c45667f2beab33c, but I had overlooked that the `Parser` for `--match` appears on both sides of a `(<|>)` expression, thereby duplicating its `--help` text. A somewhat heavy-handed but serviceable solution is to pair up the common sub-`Parsers` between the `Run` and `RunIters` `Mode`s as much as possible, which prevents the `--match` `Parser` from ever being run more than once. I've left a lengthy comment explaining how this works.