### PR TITLE
Remove entries from www/ directory from the linguist statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+www/* -linguist-detectable


### PR DESCRIPTION
This should update the project's language bar and tag it as a Haskell project (currently, Criterion is tagged as an HTML project).

This is what I mean (after applying this PR):

![criterion-linguist-bar](https://user-images.githubusercontent.com/1219667/183285234-47f97495-9009-4173-903d-848f171bf96e.png)

