### PR TITLE
Support building with `optparse-applicative-0.18.*`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.16.2
 #
-# REGENDATA ("0.14.3",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.16.2",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.2
+          - compiler: ghc-9.6.1
             compilerKind: ghc
-            compilerVersion: 9.2.2
+            compilerVersion: 9.6.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.5
+            compilerKind: ghc
+            compilerVersion: 9.4.5
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.7
+            compilerKind: ghc
+            compilerVersion: 9.2.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -96,18 +106,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -125,13 +135,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
@@ -183,14 +193,14 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -245,8 +255,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -263,7 +273,7 @@ jobs:
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
@@ -277,4 +287,10 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --enable-tests --enable-benchmarks --constraint='criterion +embed-data-files' --dependencies-only -j2 all
           $CABAL v2-build $ARG_COMPILER --enable-tests --enable-benchmarks --constraint='criterion +embed-data-files' all
           $CABAL v2-test $ARG_COMPILER --enable-tests --enable-benchmarks --constraint='criterion +embed-data-files' all
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK --enable-tests --enable-benchmarks --constraint='criterion +embed-data-files' all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK --enable-tests --enable-benchmarks --constraint='criterion +embed-data-files' all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -25,7 +25,7 @@ module Criterion.Main.Options
 
 import Control.Monad (when)
 import Criterion.Analysis (validateAccessors)
-import Criterion.Main.Options.Internal (tabulate)
+import Criterion.Main.Options.Internal (tabulate, text)
 import Criterion.Types (Config(..), Verbosity(..), measureAccessors,
                         measureKeys)
 import Data.Char (isSpace, toLower)
@@ -36,13 +36,12 @@ import Data.Version (showVersion)
 import GHC.Generics (Generic)
 import Options.Applicative
 import Options.Applicative.Help (Chunk(..))
-import Options.Applicative.Help.Pretty ((.$.))
+import Options.Applicative.Help.Pretty ((.$.), Doc)
 import Options.Applicative.Types
 import Paths_criterion (version)
 import Prelude ()
 import Prelude.Compat
 import Statistics.Types (mkCL,cl95)
-import Text.PrettyPrint.ANSI.Leijen (Doc, text)
 import qualified Data.Map as M
 
 -- | How to match a benchmark name.

--- a/Criterion/Main/Options/Internal.hs
+++ b/Criterion/Main/Options/Internal.hs
@@ -9,17 +9,22 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
--- Provides a shim on top of @optparse-applicative@'s 'Options.tabulate'
--- function that is backwards-compatible with pre-@0.17.*@ versions of
--- @optparse-applicative@. This is deliberately kept separate from the rest of
--- "Criterion.Main.Options" because this function requires CPP to define, and
+-- Provides a shim on top of @optparse-applicative@ to define two functions:
+--
+-- * Define a 'tabulate' function that is backwards-compatible with
+--   pre-@0.17.*@ versions of @optparse-applicative@.
+-- * Define a 'text' function that is forward-compatible with
+--   @optparse-applicative-0.18.*@ or later.
+--
+-- These are deliberately kept separate from the rest of
+-- "Criterion.Main.Options" because these functions require CPP to define, and
 -- there is a Haddock comment in "Criterion.Main.Options" that will cause the
 -- CPP preprocessor to trigger an \"unterminated comment\" error. Ugh.
 --
--- TODO: When we support @optparse-applicative-0.17@ as the minimum, remove
--- this module and simply inline the definition of 'tabulate' in
+-- TODO: When we support @optparse-applicative-0.18@ as the minimum, remove
+-- this module, and simply inline the definitions of 'tabulate' and 'text' in
 -- "Criterion.Main.Options".
-module Criterion.Main.Options.Internal (tabulate) where
+module Criterion.Main.Options.Internal (tabulate, text) where
 
 import qualified Options.Applicative.Help as Options
 import Options.Applicative.Help (Chunk, Doc)
@@ -35,4 +40,13 @@ tabulate :: [(Doc, Doc)] -> Chunk Doc
 tabulate = Options.tabulate (prefTabulateFill defaultPrefs)
 #else
 tabulate = Options.tabulate
+#endif
+
+-- | A shim on top of 'Options.pretty' from @optparse-applicative@ that is
+-- forward-compatible with @optparse-applicative-0.18.*@ or later.
+text :: String -> Doc
+#if MIN_VERSION_optparse_applicative(0,18,0)
+text = Options.pretty
+#else
+text = Options.text
 #endif

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+1.6.1.0
+
+* Support building with `optparse-applicative-0.18.*`.
+
 1.6.0.0
 
 * `criterion-measurement-0.2.0.0` adds the `measPeakMbAllocated` field to

--- a/criterion-measurement/criterion-measurement.cabal
+++ b/criterion-measurement/criterion-measurement.cabal
@@ -24,7 +24,9 @@ tested-with:
   GHC==8.8.4,
   GHC==8.10.7,
   GHC==9.0.2,
-  GHC==9.2.2
+  GHC==9.2.7,
+  GHC==9.4.5,
+  GHC==9.6.1
 
 flag fast
   description: compile without optimizations

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -29,7 +29,9 @@ tested-with:
   GHC==8.8.4,
   GHC==8.10.7,
   GHC==9.0.2,
-  GHC==9.2.2
+  GHC==9.2.7,
+  GHC==9.4.5,
+  GHC==9.6.1
 
 data-files:
   templates/*.css

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -1,5 +1,5 @@
 name:           criterion
-version:        1.6.0.0
+version:        1.6.1.0
 synopsis:       Robust, reliable performance measurement and analysis
 license:        BSD3
 license-file:   LICENSE
@@ -87,7 +87,6 @@ library
     -- TODO: Eventually, we should bump the lower version bounds to >=2 so that
     -- we can remove some CPP in Criterion.Report. See #247.
     aeson >= 1 && < 2.2,
-    ansi-wl-pprint >= 0.6.7.2,
     base >= 4.5 && < 5,
     base-compat-batteries >= 0.10 && < 0.14,
     binary >= 0.5.1.0,
@@ -106,8 +105,8 @@ library
     js-chart >= 2.9.4 && < 3,
     mtl >= 2,
     mwc-random >= 0.8.0.3,
-    -- TODO: Depend on optparse-applicative-0.17 as the minimum (see #258)
-    optparse-applicative >= 0.13 && < 0.18,
+    -- TODO: Depend on optparse-applicative-0.18 as the minimum (see #258)
+    optparse-applicative >= 0.13 && < 0.19,
     parsec >= 3.1.0,
     statistics >= 0.14 && < 0.17,
     text >= 0.11,

--- a/examples/criterion-examples.cabal
+++ b/examples/criterion-examples.cabal
@@ -22,7 +22,9 @@ tested-with:
   GHC==8.8.4,
   GHC==8.10.7,
   GHC==9.0.2,
-  GHC==9.2.2
+  GHC==9.2.7,
+  GHC==9.4.5,
+  GHC==9.6.1
 
 flag conduit-vs-pipes
   default: True


### PR DESCRIPTION
This adds the necessary CPP to support building `criterion` with `optparse-applicative-0.18.*` as well as older versions of the library. In a future, major release of `criterion`, we will require `optparse-applicative-0.18.*` as the minimum and explicitly depend on `prettyprinter`.