### PR TITLE
Correct contributor name for ConduitVsPipes example

### DIFF
--- a/examples/ConduitVsPipes.hs
+++ b/examples/ConduitVsPipes.hs
@@ -1,4 +1,4 @@
--- Contributed by Gabriel Gonzales as a test case for
+-- Contributed by Gabriella Gonzales as a test case for
 -- https://github.com/haskell/criterion/issues/35
 --
 -- The numbers reported by this benchmark can be made "more correct"


### PR DESCRIPTION
Very small change; but she goes by Gabriella now, and it would be good to correct the credit given in this example.